### PR TITLE
chore: fetch liquid olean cache

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           leanproject get leanprover-community/lean-liquid
           ln -s lean-liquid project
-          cd project && leanproject get-m && cd ..
+          cd project && leanproject get-m && scripts/fetch_olean_cache.sh && cd ..
           inv decls
 
       - name: Install Leanblueprint and generate web in tex env


### PR DESCRIPTION
`scripts/get-cache.sh` is a no-op if the most recent commit doesn't have cached oleans, so I went with `scripts/fetch_olean_cache.sh` instead.