### PR TITLE
modified mathbf to mathbb

### DIFF
--- a/src/macros.tex
+++ b/src/macros.tex
@@ -90,12 +90,12 @@
 \newcommand{\qproet}{{\mathrm{qpro\acute{e}t}}}
 \newcommand{\BC}{{\mathcal B\mathcal C}}
 \newcommand{\heart}{\heartsuit}
-\def\F{\mathbf{F}}
-\def\N{\mathbf{N}}
-\def\Z{\mathbf{Z}}
-\def\R{\mathbf{R}}
-\def\C{\mathbf{C}}
-\def\D{\mathbf{D}}
+\def\F{\mathbb{F}}
+\def\N{\mathbb{N}}
+\def\Z{\mathbb{Z}}
+\def\R{\mathbb{R}}
+\def\C{\mathbb{C}}
+\def\D{\mathbb{D}}
 \def\E{\mathcal{E}}
 \def\PP{\mathbf{P}}
 \def\Q{\mathbf{Q}}


### PR DESCRIPTION
Modified `\?` from `\mathbf{?}` to `\mathbb{?}` for `?=F, N, R, Z, C, D` in the `macro.tex` file because very often in the text the explicit command `\mathbb{?}` was called instead of `\?`, creating discrepancy.