### PR TITLE
modified unions to colimits

### DIFF
--- a/src/Lbar.tex
+++ b/src/Lbar.tex
@@ -69,7 +69,7 @@ and let $S$ be a finite set.
   restricts to continuous maps
   \[
     T^{-1} \cdot \_ \colon
-    \Lbar_r(S)_{\le c} \to
+    \Lbar_r(S)_{\le c} \longrightarrow
     \Lbar_r(S)_{\le c/r'}.
   \]
   In particular, $\Lbar_{r'}(S)$

--- a/src/condensed.tex
+++ b/src/condensed.tex
@@ -100,7 +100,7 @@
   where $\mathbb Z[S_i]_{\le c}$ is the set $\{\sum_{s \in S_i} n_s[s] \mid \sum_s |n_s| \le c\}$.
 
   There is a natural isomorphism between the free condensed abelian group $\mathbb Z[S]$
-  and the colimit $\bigcup_c \mathbb Z[S]_{\le c}$ of condensed sets.
+  and the colimit $\varinjlim_c \mathbb Z[S]_{\le c}$ of condensed sets.
 \end{lemma}
 
 \begin{proof}
@@ -242,7 +242,7 @@
   \uses{first_target}
   \leanok
   We have
-  \[ Q'(\overline{\mathcal M}_{r'}(S)) = \bigcup_n Q'(\overline{\mathcal M}_{r'}(S))_{\leq n}, \]
+  \[ Q'(\overline{\mathcal M}_{r'}(S)) = \varinjlim_n Q'(\overline{\mathcal M}_{r'}(S))_{\leq n}, \]
   inducing a resolution
   \[ 0\to \bigoplus_n Q'(\overline{\mathcal M}_{r'}(S))_{\leq n}\to \bigoplus_n Q'(\overline{\mathcal M}_{r'}(S))_{\leq n}\to Q'(\overline{\mathcal M}_{r'}(S))\to 0.  \]
   Passing to a corresponding long exact sequence reduces one to checking that the squares

--- a/src/measures.tex
+++ b/src/measures.tex
@@ -11,7 +11,7 @@
   \]
 	endowed with the $\ell^{p'}$-norm $\Vert \sum_{s\in S}a_s[s]\Vert_{\ell^{p'}}=\sum_{s\in S}\lvert a_s\rvert ^{p'}$.
 
-  For every finite set $S$, the space $\Rm(S)$ can be written as the union
+  For every finite set $S$, the space $\Rm(S)$ can be written as the colimit (or simply the union, in this case)
   \[
     \Rm(S) = \varinjlim_{c>0}\Rm(S)_{\leq c}
   \]

--- a/src/normed_groups.tex
+++ b/src/normed_groups.tex
@@ -43,7 +43,7 @@ The remainder of this subsection sets up some algebraic variants of semi-normed 
   such that each $M_c$ contains $0$, is closed under negation,
   and $M_{c_1} + M_{c_2} \subseteq M_{c_1 + c_2}$. An example would be $M=\mathbb{R}$ or $M=\mathbb{Q}_p$ with $M_c :=\{x\,:\,|x|\leq c\}$.
 
-  A pseudo-normed group $M$ is \emph{exhaustive} if $\bigcup_c M_c = M$.
+  A pseudo-normed group $M$ is \emph{exhaustive} if $\varinjlim_c M_c = M$.
 \end{definition}
 
 All pseudo-normed groups that we consider will have a topology on the filtration sets $M_c$.

--- a/src/normed_groups2.tex
+++ b/src/normed_groups2.tex
@@ -52,15 +52,15 @@ started in Subsection~\ref{sec:normed_groups}.
   Then
   \[ X_{\leq c} := \varprojlim_i X_{i,\leq c} \]
   is compact Hausdorff, and
-  \[ X=\bigcup_c X_{\leq c} \]
+  \[ X=\varinjlim_c X_{\leq c} \]
   is naturally a compact-Hausdorffly-filtered pseudonormed abelian group
-  which is the limit of $(X_i)_i$ in the strict category structure.
+  which is the colimit of $(X_i)_i$ in the strict category structure.
 \end{proposition}
 
 \begin{proof}
   \leanok
   One can define negation and addition on $X$ as continuous maps
-  $-: X_{\leq c}\to X_{\leq c}$ and $+: X_{\leq c}\times X_{\leq c'}\to X_{\leq c+c'}$, and these pass to the unions.
+  $-: X_{\leq c}\to X_{\leq c}$ and $+: X_{\leq c}\times X_{\leq c'}\to X_{\leq c+c'}$, and these pass to the colimit.
   It should then be straightforward to check the axioms.
 \end{proof}
 

--- a/src/normed_groups2.tex
+++ b/src/normed_groups2.tex
@@ -54,7 +54,7 @@ started in Subsection~\ref{sec:normed_groups}.
   is compact Hausdorff, and
   \[ X=\varinjlim_c X_{\leq c} \]
   is naturally a compact-Hausdorffly-filtered pseudonormed abelian group
-  which is the colimit of $(X_i)_i$ in the strict category structure.
+  which is the limit of $(X_i)_i$ in the strict category structure.
 \end{proposition}
 
 \begin{proof}


### PR DESCRIPTION
Modified all symbols `\cup` and `\bigcup` to `varinjlim` (and two explicits "union" to "colimit").